### PR TITLE
[fix] Was failing test 'winston.accept' with winston >= v0.5.6 (and possibly earlier).

### DIFF
--- a/lib/logentries.js
+++ b/lib/logentries.js
@@ -255,7 +255,9 @@ function Logger( opts ) {
 
         self.winstonLogger = this
       }
-
+      
+      util.inherits(LogentriesLogger, winston.Transport)
+      
       LogentriesLogger.prototype.log = function (level, msg, meta, callback) {
         var data = msg + (meta?' '+JSON.stringify(meta):'')
         self.log(level,data)


### PR DESCRIPTION
node accept/winston.accept.js

node.js:134
        throw e; // process.nextTick error, or 'error' event on first tick
        ^
TypeError: Object [object Object] has no method 'on'
    at [object Object].add (/path/to/node-logentries/node_modules/winston/lib/winston/logger.js:284:12)
    at Object.add (/path/to/node-logentries/node_modules/winston/lib/winston.js:81:34)
    at Logger.winston (/path/to/node-logentries/lib/logentries.js:268:13)
    at Object.<anonymous> (/path/to/node-logentries/accept/winston.accept.js:10:5)
    at Module._compile (module.js:402:26)
    at Object..js (module.js:408:10)
    at Module.load (module.js:334:31)
    at Function._load (module.js:293:12)
    at Array.<anonymous> (module.js:421:10)
    at EventEmitter._tickCallback (node.js:126:26)

All tests pass using winston v0.5.6/7 and node v0.4.10.
