### PR TITLE
Hanging Client Fix

### DIFF
--- a/lib/logentries.js
+++ b/lib/logentries.js
@@ -26,6 +26,7 @@ function LogEntriesTransport( opts, logger ) {
         queue.shift()
         logger.emit('log',logline)
         req.write(logline)
+        req.end()
       }
       catch(e) {
         logger.emit('error',e)


### PR DESCRIPTION
This is a one liner to prevent a 6.x client hanging when writing to the req object. 
