### PR TITLE
Format Multi-line events differently on Token TCP input

### DIFF
--- a/lib/logentries.js
+++ b/lib/logentries.js
@@ -200,7 +200,10 @@ function Logger( opts ) {
       else {
         args[1] = ''+data;
       }
-            
+          
+	  //Replace newlines with unicode line separator
+	  args[1] = args[1].replace(/\n/g, "\u2028");
+  
       if (timestamp) {
         var t = new Date().toISOString();
         args.unshift(t);


### PR DESCRIPTION
Hey Richard,

One thing I forgot, when switching this lib from using HTTP PUT to our Token TCP method was that multi-line events get chopped. Newline characters are event delimiters when logs reach our API servers, so because each log event needs to be prefixed with a Token now, only the first line of a multi-line events make it, and the rest are considered to have no token prefixed and our thus discarded. To solve this, you can replace newlines with unicode line separator \u2028 which we don't delimit on but display as a newline in the UI.

I just added a simple replace statement on the data after it's converted to a string.

Thanks,
Mark
