### PR TITLE
Allow custom levels to be set when using winston

### DIFF
--- a/lib/logentries.js
+++ b/lib/logentries.js
@@ -272,7 +272,7 @@ function Logger( opts ) {
       delete self[l]
     }
 
-    self.levels = winston.levels
+    self.levels = opts.levels || winston.levels
 
     if( !winston.transports.LogentriesLogger )  {
       var LogentriesLogger = winston.transports.LogentriesLogger = function (options) {


### PR DESCRIPTION
Usage:
log.winston( winston, { level:'silly' , levels: { silly: 0, info: 1, error: 2} } )

Since the method originally ignored any custom levels sent when initialising the logger, this does too but this PR allows you to set custom levels when the winston method is called.
