### PR TITLE
Make printerror work as documented

### DIFF
--- a/lib/logentries.js
+++ b/lib/logentries.js
@@ -27,7 +27,7 @@ function LogEntriesTransport( opts, logger ) {
       } else {
         logline += ' ' + entry.join(' ') + '\n'
       }
-      
+
       try {
         queue.shift()
         logger.emit('log',logline)
@@ -64,7 +64,7 @@ function LogEntriesTransport( opts, logger ) {
 
     if (opts.secure) {
       socket = tls.connect(options.port, options.host, secureConnection)
-    } 
+    }
     else {
       socket = net.createConnection(options.port, options.host)
     }
@@ -140,7 +140,7 @@ function LogEntriesTransport( opts, logger ) {
  *    transport:  LogEntriesTransport; transport object
  *    levels:     syslog-style; custom log levels
  *    printerror: true; print errors to STDERR with console.error
- *    secure: false; Use tls for communication 
+ *    secure: false; Use tls for communication
  *    flatten: true; JSON entries will be flattened.
  */
 function Logger( opts ) {
@@ -158,6 +158,13 @@ function Logger( opts ) {
       console.error(err)
     }
   })
+  //as opposed to invoking a callback repeatedly that may never do anything useful,
+  //only append a callback if 'printerror' is set in constructor
+  if(opts.printerror) {
+    self.on('log',function(err) {
+      console.log(err);
+    })
+  }
 
   self.levels = opts.levels || {
     debug     :0,
@@ -176,7 +183,7 @@ function Logger( opts ) {
   var queue = []
 
   transport.queue(queue)
-  
+
 
   for( var level in self.levels ) {
     if( !({log:1,end:1,level:1,levels:1,on:1,once:1}[level]) ) {
@@ -208,9 +215,9 @@ function Logger( opts ) {
     var args = Array.prototype.slice.call(arguments)
     var arglevel = args[0]
     var levelval = self.levels[arglevel]
-    var timestamp = 
+    var timestamp =
       opts.timestamp === undefined || opts.timestamp === true ? true : false;
-      
+
     if( undefined == levelval ) {
       self.emit('error','unknown log level: '+arglevel)
     }
@@ -220,33 +227,33 @@ function Logger( opts ) {
       var data = args[1]
       if( data && data.toISOString && data.getTimezoneOffset ) {
         args[1] = data.toISOString();
-      }      
+      }
       else if( data && 'object' == typeof( data ) || Array.isArray(data) ) {
         args[1] = opts.flatten ? flatten(data, '') : JSON.stringify(data)
       }
       else {
         args[1] = ''+data
       }
-          
+
 	    //Replace newlines with unicode line separator
       args[1] = args[1].replace(/\n/g, "\u2028")
-  
+
       if (timestamp) {
         var t = new Date().toISOString()
         args.unshift(t)
       }
-      
+
       queue.push(args)
       transport.consume()
     }
   }
 
-  
+
   self.end = function() {
     transport.end && transport.end()
   }
 
-  
+
   self.level = function(level) {
 
     if( undefined != level ) {
@@ -266,7 +273,7 @@ function Logger( opts ) {
     return levelname
   }
 
-  
+
   self.winston = function(winston,opts) {
     for( var l in self.levels ) {
       delete self[l]
@@ -288,13 +295,13 @@ function Logger( opts ) {
 
         self.winstonLogger = this
       }
-      
+
       util.inherits(LogentriesLogger, winston.Transport)
-      
+
       LogentriesLogger.prototype.log = function (level, msg, meta, callback) {
         var data = msg + (meta?' '+JSON.stringify(meta):'')
         self.log(level,data)
-        callback(null, true); 
+        callback(null, true);
       }
     }
 
@@ -310,4 +317,3 @@ util.inherits(Logger, events.EventEmitter);
 exports.logger = function(opts) {
   return new Logger(opts)
 }
-


### PR DESCRIPTION
Fixes issue #24 if I understand this correctly

Sorry about the stupid pointless noise about lines with trailing spaces - dumb atom.io insists on changing those out from under me.

The only real change is at line 161 or so - https://github.com/uberbrady/node-logentries/compare/rjrodger:master...master#diff-7d335aef4feb2aaa3277bb0a724fa594R161 - where I just add another callback to listen for on('log') if the printerror option is enabled.

If the weird whitespace noise is too annoying, please let me know and I'll find another way to make a pull request that will just encapsulate the actual change being made.