### PR TITLE
Expose connect method

### DIFF
--- a/lib/logentries.js
+++ b/lib/logentries.js
@@ -74,6 +74,7 @@ function LogEntriesTransport( opts, logger ) {
     function handleConnection() {
       connecting = false
       connected = true
+      logger.emit('ready')
       process()
     }
 
@@ -105,6 +106,7 @@ function LogEntriesTransport( opts, logger ) {
     });
   }
 
+  logger.connect = connect;
 
   self.queue = function( q ) {
     queue = q


### PR DESCRIPTION
Exposes the connect method and adds a `ready` event, allowing non-long running processes to initialize a connection before logging to logentries. Fixes issue #28.