### PR TITLE
Add "printlevel" option to Logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ When you create a _log_ object with the _logger_ function on the module, you can
    * _printerror_: optional; default is true; print errors to STDERR with console.error
    * _timestamp_: optional; default is true; autogenerate a timestamp
    * _usequotes_: optional; default is false; add double quotes around every field
+   * _printlevel_: optional; default is true; print log level to log (e.g. "info ~~~~~~")
 
 The _token_  entry relates to your logentries.com configuration. The _transport_ option allows you to 
 provide an alternative transport implementation (see below). 

--- a/lib/logentries.js
+++ b/lib/logentries.js
@@ -142,6 +142,7 @@ function LogEntriesTransport( opts, logger ) {
  *    printerror: true; print errors to STDERR with console.error
  *    secure: false; Use tls for communication 
  *    flatten: true; JSON entries will be flattened.
+ *    printlevel: true; log level will be printed to log (e.g. "info ~~~~~~").
  */
 function Logger( opts ) {
   var self = this

--- a/lib/logentries.js
+++ b/lib/logentries.js
@@ -149,6 +149,7 @@ function Logger( opts ) {
 
   opts = opts || {}
 
+  opts.printlevel = 'undefined' == typeof(opts.printlevel) ? true : opts.printlevel
   opts.printerror = 'undefined' == typeof(opts.printerror) ? true : opts.printerror
   opts.flatten = 'undefined' == typeof(opts.flatten) ? true : opts.flatten
 
@@ -235,6 +236,8 @@ function Logger( opts ) {
         var t = new Date().toISOString()
         args.unshift(t)
       }
+
+      if (!opts.printlevel) args.shift()
       
       queue.push(args)
       transport.consume()


### PR DESCRIPTION
Right now, the log level (e.g. "info", "fatal") is being written to Logentries with every entry, and there doesn't seem to be a way to prevent this. This might not be optimal; in particular, it prevents Logentries' smart "Expand JSON" feature from being applied to logs.