### PR TITLE
Don't add a new logger to winston, just return the transport

### DIFF
--- a/lib/logentries.js
+++ b/lib/logentries.js
@@ -298,7 +298,7 @@ function Logger( opts ) {
       }
     }
 
-    winston.add(LogentriesLogger,opts)
+    return new (winston.transports.LogentriesLogger)(opts)
   }
 
 


### PR DESCRIPTION
This is for a project using [actionhero](http://www.actionherojs.com/), which allows you to configure logging by adding winston transports. The `winston` function tries to add the logger to winston directly, which breaks things. This pull request changes it to return a new transport instead, which can then be used however the caller wants.