### PR TITLE
Add constructor option to change the bufferSize property

### DIFF
--- a/src/node_modules/logger.js
+++ b/src/node_modules/logger.js
@@ -82,7 +82,7 @@ const enumerable = (target, name, descriptor) => {
 
 export default class Logger extends Writable {
 	constructor(opts) {
-		super({ objectMode: true, highWaterMark: defaults.bufferSize });
+		super({ objectMode: true, highWaterMark: opts.bufferSize || defaults.bufferSize });
 
 		// Sanity checks
 
@@ -596,7 +596,7 @@ if (winston) Logger.provisionWinston();
 
 class BunyanStream extends Writable {
 	constructor(opts) {
-		super({ objectMode: true, highWaterMark: defaults.bufferSize });
+		super({ objectMode: true, highWaterMark: opts.bufferSize || defaults.bufferSize });
 
 		opts = _.clone(opts || {});
 


### PR DESCRIPTION
We have some errors raising from Logentries used with Winston. Sometime we have massive error rate due to maybe a network issue, but the cause is that buffer is full from time to time. 

We have on average 2k req/minutes, and each are generating 5 logs ~ so a connection lost (3 sec timeout in your defaults.js) fill the buffer quite fast.

With the ability to change the buffer size, we could handle the connections drops to Logentries