### PR TITLE
Support Winston 2 log levels

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1852,6 +1852,16 @@
         }
       }
     },
+    "winston1": {
+      "version": "1.1.2",
+      "from": "winston1@*",
+      "resolved": "https://registry.npmjs.org/winston1/-/winston1-1.1.2.tgz"
+    },
+    "winston2x": {
+      "version": "2.1.1",
+      "from": "winston2x@*",
+      "resolved": "https://registry.npmjs.org/winston2x/-/winston2x-2.1.1.tgz"
+    },
     "semver": {
       "version": "5.1.0",
       "from": "semver@*",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1851,6 +1851,11 @@
           "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
         }
       }
+    },
+    "semver": {
+      "version": "5.1.0",
+      "from": "semver@*",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "babel-runtime": "5.4.7",
     "codependency": "0.1.4",
     "json-stringify-safe": "5.0.1",
-    "lodash": "3.9.3"
+    "lodash": "3.9.3",
+    "semver": "^5.1.0"
   },
   "devDependencies": {
     "babel-eslint": "^3.1.23",

--- a/package.json
+++ b/package.json
@@ -60,9 +60,13 @@
     "mitm": "^1.1.0",
     "tap-spec": "^3.0.0",
     "tape": "^4.0.0",
-    "winston": "^1.0.0"
+    "winston": "^1.0.0",
+    "winston1": "^1.1.2",
+    "winston2x": "^2.1.1"
   },
   "optionalPeerDependencies": {
-    "winston": "*"
+    "winston": "*",
+    "winston1": "*",
+    "winston2x": "*"
   }
 }

--- a/src/node_modules/logger.js
+++ b/src/node_modules/logger.js
@@ -538,7 +538,13 @@ export default class Logger extends Writable {
 				opts.minLevel =
 					opts.minLevel || opts.level || this[$tempLevel] || 0;
 
-				opts.levels = opts.levels || winston.levels;
+				// Winston and Logengries levels are reversed
+				// (i.e.: 'error' level is 0 for Winston and 5 for Logentries)
+				// If the user provides custom levels we assue they are using winston standard
+				let levels = opts.levels || winston.levels;
+				let values = _.values(levels).reverse();
+				opts.levels = {};
+				_.keys(levels).forEach((k, i) => opts.levels[k] = values[i]);
 
 				delete this[$tempLevel];
 

--- a/src/node_modules/logger.js
+++ b/src/node_modules/logger.js
@@ -634,6 +634,13 @@ const winston = requirePeer('winston', { optional: true });
 
 if (winston) Logger.provisionWinston(winston);
 
+// Provision too the winston static versions for testing/development purposes
+const winston1 = requirePeer('winston1', { optional: true });
+const winston2 = requirePeer('winston2x', { optional: true });
+
+if (winston1) Logger.provisionWinston(winston1);
+if (winston2) Logger.provisionWinston(winston2);
+
 // BUNYAN STREAM ///////////////////////////////////////////////////////////////
 
 class BunyanStream extends Writable {

--- a/src/node_modules/logger.js
+++ b/src/node_modules/logger.js
@@ -2,6 +2,7 @@
 // IMPORTS /////////////////////////////////////////////////////////////////////
 
 import _                                    from 'lodash';
+import semver                               from 'semver';
 import * as defaults                        from 'defaults';
 import * as levelUtil                       from 'levels';
 import codependency                         from 'codependency';
@@ -538,13 +539,16 @@ export default class Logger extends Writable {
 				opts.minLevel =
 					opts.minLevel || opts.level || this[$tempLevel] || 0;
 
-				// Winston and Logengries levels are reversed
-				// (i.e.: 'error' level is 0 for Winston and 5 for Logentries)
-				// If the user provides custom levels we assue they are using winston standard
-				let levels = opts.levels || winston.levels;
-				let values = _.values(levels).reverse();
-				opts.levels = {};
-				_.keys(levels).forEach((k, i) => opts.levels[k] = values[i]);
+				opts.levels = opts.levels || winston.levels;
+				if (semver.satisfies(winston.version, '>=2.0.0')) {
+					// Winston and Logengries levels are reversed
+					// (i.e.: 'error' level is 0 for Winston and 5 for Logentries)
+					// If the user provides custom levels we assue they are using winston standard
+					let levels = opts.levels;
+					let values = _.values(levels).reverse();
+					opts.levels = {};
+					_.keys(levels).forEach((k, i) => opts.levels[k] = values[i]);
+				}
 
 				delete this[$tempLevel];
 

--- a/src/node_modules/logger.js
+++ b/src/node_modules/logger.js
@@ -522,8 +522,7 @@ export default class Logger extends Writable {
 	// Static methods
 
 	@unwritable
-	static provisionWinston() {
-		const winston = requirePeer('winston');
+	static provisionWinston(winston) {
 
 		if (winston.transports.Logentries) return;
 
@@ -633,7 +632,7 @@ export default class Logger extends Writable {
 
 const winston = requirePeer('winston', { optional: true });
 
-if (winston) Logger.provisionWinston();
+if (winston) Logger.provisionWinston(winston);
 
 // BUNYAN STREAM ///////////////////////////////////////////////////////////////
 

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,8 @@ var Logger   = require('../lib/node_modules/logger.js');
 var mitm     = require('mitm');
 var tape     = require('tape');
 var winston  = require('winston');
+var winston1 = require('winston1');
+var winston2 = require('winston2x');
 
 // FAKE TOKEN //////////////////////////////////////////////////////////////////
 
@@ -571,6 +573,94 @@ tape("Winston supports json logging.", function(t) {
       		new (winston.transports.Logentries)({ token: x, json: true })
     	]
   	});
+
+	mockTest(function(data) {
+		t.pass("winston logs in json format");
+		var expect = {
+			message: "msg",
+			foo: "bar",
+			level: "warn"
+		};
+		t.equal(data, x + " " + JSON.stringify(expect) + '\n', 'json as expected');
+	});
+
+	logger.warn("msg", {foo: "bar"});
+});
+
+tape('Winston@1.1.2 integration is provided.', function(t) {
+	t.plan(4);
+	t.timeoutAfter(2000);
+
+	t.true(winston1.transports.Logentries,
+		'provisioned constructor automatically');
+
+	t.doesNotThrow(function() {
+		winston1.add(winston1.transports.Logentries, { token: x });
+	}, 'transport can be added');
+
+	winston1.remove(winston1.transports.Console);
+
+	mockTest(function(data) {
+		t.pass('winston log transmits');
+		t.equal(data, x + ' warn mysterious radiation\n', 'msg as expected');
+	});
+
+	winston1.warn('mysterious radiation');
+});
+
+tape("Winston@1.1.2 supports json logging.", function(t) {
+	t.plan(2);
+	t.timeoutAfter(2000);
+
+	var logger = new (winston1.Logger)({
+		transports: [
+			new (winston1.transports.Logentries)({ token: x, json: true })
+		]
+	});
+
+	mockTest(function(data) {
+		t.pass("winston logs in json format");
+		var expect = {
+			message: "msg",
+			foo: "bar",
+			level: "warn"
+		};
+		t.equal(data, x + " " + JSON.stringify(expect) + '\n', 'json as expected');
+	});
+
+	logger.warn("msg", {foo: "bar"});
+});
+
+tape('Winston@2.1.1 integration is provided.', function(t) {
+	t.plan(4);
+	t.timeoutAfter(2000);
+
+	t.true(winston2.transports.Logentries,
+		'provisioned constructor automatically');
+
+	t.doesNotThrow(function() {
+		winston2.add(winston2.transports.Logentries, { token: x });
+	}, 'transport can be added');
+
+	winston2.remove(winston2.transports.Console);
+
+	mockTest(function(data) {
+		t.pass('winston log transmits');
+		t.equal(data, x + ' warn mysterious radiation\n', 'msg as expected');
+	});
+
+	winston2.warn('mysterious radiation');
+});
+
+tape("Winston@2.1.1 supports json logging.", function(t) {
+	t.plan(2);
+	t.timeoutAfter(2000);
+
+	var logger = new (winston2.Logger)({
+		transports: [
+			new (winston2.transports.Logentries)({ token: x, json: true })
+		]
+	});
 
 	mockTest(function(data) {
 		t.pass("winston logs in json format");


### PR DESCRIPTION
I faced a problem when adding this transport to my winston instance. When trying to send logs to Logentries I was only receiving the logs with `level` strictly equal to the minimum level of logging passed to winston.
This was my winston transports config:
```js
	transports: [
		...
		new LogentriesTransport({
			level: 'debug',
			token: '<My token>'
		})
	]
```

The problem was actually quite simple; on `le_node` error levels are defined from lower to higher, on winston are reversed, so while one is doing "greater or equal than" compassion, the other one is doing the opposite.

A workaround was to pass a levels object to the Logentries transport with the reversed order of winston levels:
```js
	transports: [
		...
		new LogentriesTransport({
			level: 'debug',
			levels: { error: 5, warn: 4, info: 3, verbose: 2, debug: 1, silly: 0 },
			token: '<My token>'
		})
	]
```
(Notice that by default winston levels are `{ error: 0, warn: 1, info: 2, verbose: 3, debug: 4, silly: 5 }`)

So the solution I came up with is when using `provisionWinston`, before passing the `opts` object to the `Logger`, take the levels values and reverse them. If the user is using custom levels he is probably using it according to the winston standard, so we act the same way.

**Edit**: 
Ok, after seeing the Travis tests fail I realised this error is caused by this commit
https://github.com/winstonjs/winston/commit/438331a31be507669998fe5aad671b489f2afeda

On the change from 1.x to 2.x they reversed the codes.

I added semver checking on the winston version, maybe its not the best of the solutions... I'll leave to the repo contributors to decide if its worth taking it.

Closes #87
