### PR TITLE
#106 fix error on serializing object that inherits from non-object

### DIFF
--- a/src/node_modules/serialize.js
+++ b/src/node_modules/serialize.js
@@ -46,6 +46,9 @@ export const build = ({ flatten, flattenArrays, replacer = pass,
 		if (_.isObject(val) && !Object.getPrototypeOf(val))
 			return val;
 
+		if (_.isObject(val) && !(val instanceof Object))
+			return val;
+
 		// Trouble primitives
 		if (_.isNaN(val))              return 'NaN';
 		if (val === Infinity)          return 'Infinity';

--- a/test/test.js
+++ b/test/test.js
@@ -238,6 +238,24 @@ tape('Circular references don’t make the sad times.', function(t) {
 	t.end();
 });
 
+tape('Serialize objects that inherit from non-Object objects fine', function(t) {
+	function NullObj() {}
+	NullObj.prototype = Object.create(null);
+	var newObj = new NullObj();
+
+	newObj.prop = 1;
+
+	var logger = new Logger({ token: x });
+
+	var res = JSON.parse(logger.serialize(newObj));
+
+	t.true(res, 'object from non object doesn’t throw');
+
+	t.equal(res.prop, 1, 'properties are still seen');
+
+	t.end();
+});
+
 tape('Object.create(null) objects don’t destroy everything.', function(t) {
 	var nullObj = Object.create(null);
 


### PR DESCRIPTION
#106
Fixing serialize function for object that inherits from non-object. This is for breaking changes on Node 6.x.
Ref: [https://github.com/nodejs/node/wiki/Breaking-changes-between-v5-and-v6#events](https://github.com/nodejs/node/wiki/Breaking-changes-between-v5-and-v6#events)
