### PR TITLE
Rename default config retryMax to maxRetry

### DIFF
--- a/src/node_modules/defaults.js
+++ b/src/node_modules/defaults.js
@@ -13,7 +13,7 @@ export const portSecure = 443;
 export const timeouts = {
 	connection: {
 		idle: 3 * 60 * 1000,
-		retryMax: 15 * 60 * 1000
+		maxRetry: 15 * 60 * 1000
 	}
 };
 


### PR DESCRIPTION
The code references `maxRetry`:
https://github.com/logentries/le_node/blob/master/src/node_modules/logger.js#L319